### PR TITLE
Fix while loop multiple clients

### DIFF
--- a/wg-clients-guardian
+++ b/wg-clients-guardian
@@ -34,11 +34,11 @@ readonly TELEGRAM_CHAT_ID=$(awk -F'=' '/^chat=/ { print $2}' $1)
 readonly TELEGRAM_TOKEN=$(awk -F'=' '/^token=/ { print $2}' $1)
 
 while IFS= read -r LINE; do
-	PUBLIC_KEY=$(awk '{ print $1 }' <<< "$LINE")
-	REMOTE_IP=$(awk '{ print $3 }' <<< "$LINE" | awk -F':' '{print $1}')
-	LAST_SEEN=$(awk '{ print $5 }' <<< "$LINE")
-	CLIENT_NAME=$(grep -R "$PUBLIC_KEY" /etc/wireguard/keys/ | awk -F"/etc/wireguard/keys/|_pub:" '{print $2}' | sed -e 's./..g')
-	CLIENT_FILE="$CLIENTS_DIRECTORY/$CLIENT_NAME.txt"
+	readonly PUBLIC_KEY=$(awk '{ print $1 }' <<< "$LINE")
+	readonly REMOTE_IP=$(awk '{ print $3 }' <<< "$LINE" | awk -F':' '{print $1}')
+	readonly LAST_SEEN=$(awk '{ print $5 }' <<< "$LINE")
+	readonly CLIENT_NAME=$(grep -R "$PUBLIC_KEY" /etc/wireguard/keys/ | awk -F"/etc/wireguard/keys/|_pub:" '{print $2}' | sed -e 's./..g')
+	readonly CLIENT_FILE="$CLIENTS_DIRECTORY/$CLIENT_NAME.txt"
 
 	# create the client file if not exists.
 	if [ ! -f "$CLIENT_FILE" ]; then
@@ -49,16 +49,16 @@ while IFS= read -r LINE; do
 	send_notification="no"
 	  
 	# last client status
-	LAST_CONNECTION_STATUS=$(cat $CLIENT_FILE)
+	readonly LAST_CONNECTION_STATUS=$(cat $CLIENT_FILE)
 	  
 	# elapsed seconds from last connection
-	LAST_SEEN_SECONDS=$(date -d @"$LAST_SEEN" '+%s')
+	readonly LAST_SEEN_SECONDS=$(date -d @"$LAST_SEEN" '+%s')
 	
 	# it the user is online
 	if [ "$LAST_SEEN" -ne 0 ]; then
 
 		# elaped minutes from last connection
-		LAST_SEEN_ELAPSED_MINUTES=$((10#$(($NOW - $LAST_SEEN_SECONDS)) / 60))
+		readonly LAST_SEEN_ELAPSED_MINUTES=$((10#$(($NOW - $LAST_SEEN_SECONDS)) / 60))
 
 		# if the previous state was online and the elapsed minutes are greater then TIMEOUT, the user is offline
 		if [ $LAST_SEEN_ELAPSED_MINUTES -gt $TIMEOUT ] && [ "online" == $LAST_CONNECTION_STATUS ]; then

--- a/wg-clients-guardian
+++ b/wg-clients-guardian
@@ -34,11 +34,11 @@ readonly TELEGRAM_CHAT_ID=$(awk -F'=' '/^chat=/ { print $2}' $1)
 readonly TELEGRAM_TOKEN=$(awk -F'=' '/^token=/ { print $2}' $1)
 
 while IFS= read -r LINE; do
-	readonly PUBLIC_KEY=$(awk '{ print $1 }' <<< "$LINE")
-	readonly REMOTE_IP=$(awk '{ print $3 }' <<< "$LINE" | awk -F':' '{print $1}')
-	readonly LAST_SEEN=$(awk '{ print $5 }' <<< "$LINE")
-	readonly CLIENT_NAME=$(grep -R "$PUBLIC_KEY" /etc/wireguard/keys/ | awk -F"/etc/wireguard/keys/|_pub:" '{print $2}' | sed -e 's./..g')
-	readonly CLIENT_FILE="$CLIENTS_DIRECTORY/$CLIENT_NAME.txt"
+	PUBLIC_KEY=$(awk '{ print $1 }' <<< "$LINE")
+	REMOTE_IP=$(awk '{ print $3 }' <<< "$LINE" | awk -F':' '{print $1}')
+	LAST_SEEN=$(awk '{ print $5 }' <<< "$LINE")
+	CLIENT_NAME=$(grep -R "$PUBLIC_KEY" /etc/wireguard/keys/ | awk -F"/etc/wireguard/keys/|_pub:" '{print $2}' | sed -e 's./..g')
+	CLIENT_FILE="$CLIENTS_DIRECTORY/$CLIENT_NAME.txt"
 
 	# create the client file if not exists.
 	if [ ! -f "$CLIENT_FILE" ]; then
@@ -49,16 +49,16 @@ while IFS= read -r LINE; do
 	send_notification="no"
 	  
 	# last client status
-	readonly LAST_CONNECTION_STATUS=$(cat $CLIENT_FILE)
+	LAST_CONNECTION_STATUS=$(cat $CLIENT_FILE)
 	  
 	# elapsed seconds from last connection
-	readonly LAST_SEEN_SECONDS=$(date -d @"$LAST_SEEN" '+%s')
+	LAST_SEEN_SECONDS=$(date -d @"$LAST_SEEN" '+%s')
 	
 	# it the user is online
 	if [ "$LAST_SEEN" -ne 0 ]; then
 
 		# elaped minutes from last connection
-		readonly LAST_SEEN_ELAPSED_MINUTES=$((10#$(($NOW - $LAST_SEEN_SECONDS)) / 60))
+		LAST_SEEN_ELAPSED_MINUTES=$((10#$(($NOW - $LAST_SEEN_SECONDS)) / 60))
 
 		# if the previous state was online and the elapsed minutes are greater then TIMEOUT, the user is offline
 		if [ $LAST_SEEN_ELAPSED_MINUTES -gt $TIMEOUT ] && [ "online" == $LAST_CONNECTION_STATUS ]; then

--- a/wg-clients-guardian
+++ b/wg-clients-guardian
@@ -83,7 +83,7 @@ while IFS= read -r LINE; do
 		readonly MESSAGE="🐉 Wireguard: \`$CLIENT_NAME is $send_notification from ip address $REMOTE_IP\`"
 		curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" -F chat_id=$TELEGRAM_CHAT_ID -F text="$MESSAGE" -F parse_mode="MarkdownV2" > /dev/null 2>&1
 	else
-		printf "The client %s is %s, no notification will be sent.\n" $CLIENT_NAME $(cat $CLIENT_FILE)
+		printf "The client %s is %s, no notification will be send.\n" $CLIENT_NAME $(cat $CLIENT_FILE)
 	fi
 
 done <<< "$WIREGUARD_CLIENTS"

--- a/wg-clients-guardian
+++ b/wg-clients-guardian
@@ -83,7 +83,7 @@ while IFS= read -r LINE; do
 		readonly MESSAGE="🐉 Wireguard: \`$CLIENT_NAME is $send_notification from ip address $REMOTE_IP\`"
 		curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" -F chat_id=$TELEGRAM_CHAT_ID -F text="$MESSAGE" -F parse_mode="MarkdownV2" > /dev/null 2>&1
 	else
-		printf "The client %s is %s, no notification will be send.\n" $CLIENT_NAME $(cat $CLIENT_FILE)
+		printf "The client %s is %s, no notification will be sent.\n" $CLIENT_NAME $(cat $CLIENT_FILE)
 	fi
 
 done <<< "$WIREGUARD_CLIENTS"


### PR DESCRIPTION
The readonly attribute caused the variables in the while loop to be unmodifiable. This made it so in the event of multiple clients existing, only the first one would be processed.