### PR TITLE
Added support to wgdashboard db to query client name from public key

### DIFF
--- a/.config-example
+++ b/.config-example
@@ -14,6 +14,12 @@ wgdashboard_api_url=
 ; API key for wgdashboard (optional). Required when `wgdashboard_api_url` is set.
 ; Full documentation for API https://docs.wgdashboard.dev/api/
 wgdashboard_api_key=
+; API cache time-to-live in seconds (optional). How long to cache the API response. Default: 86400 (24 hours)
+wgdashboard_api_ttl=86400
+; API retry count (optional). Number of times to retry the API call if it fails. Default: 3
+wgdashboard_api_retry_count=3
+; API retry sleep time in seconds (optional). How long to wait between retry attempts. Default: 1
+wgdashboard_api_retry_sleep=5
 
 [telegram]
 ; Register your telegram bot https://core.telegram.org/bots

--- a/.config-example
+++ b/.config-example
@@ -8,11 +8,12 @@ notification_channel=both
 ; After X minutes the clients will be considered disconnected
 ; Choose a timeout greater then 5 minutes to limit many false positives
 timeout=5
-; Path to the wgdashboard database to get client name 
-; Wgdashboard does not necesseraily write the configuration files to disk with the client names
-; If empty the feature will be disabled
-; Possible path example: /etc/wgdashboard/src/db/wgdashboard.db
-wgdashboard_db_path=
+; Wgdashboard API base URL (optional). If set, the script will call the API
+; Example: https://your-wgdashboard-host
+wgdashboard_api_url=
+; API key for wgdashboard (optional). Required when `wgdashboard_api_url` is set.
+; Full documentation for API https://docs.wgdashboard.dev/api/
+wgdashboard_api_key=
 
 [telegram]
 ; Register your telegram bot https://core.telegram.org/bots

--- a/.config-example
+++ b/.config-example
@@ -8,6 +8,11 @@ notification_channel=both
 ; After X minutes the clients will be considered disconnected
 ; Choose a timeout greater then 5 minutes to limit many false positives
 timeout=5
+; Path to the wgdashboard database to get client name 
+; Wgdashboard does not necesseraily write the configuration files to disk with the client names
+; If empty the feature will be disabled
+; Possible path example: /etc/wgdashboard/src/db/wgdashboard.db
+wgdashboard_db_path=
 
 [telegram]
 ; Register your telegram bot https://core.telegram.org/bots

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ git clone https://github.com/yourusername/wireguard-client-connection-notificati
 
 2. Edit the `.config` file to include your notification settings. Make sure to configure either Telegram or Gotify server details.
 
+   Optional: Integrate with `wgdashboard` to resolve peer public keys to client names. This is done via the `getWireguardConfigurationInfo` API: set `wgdashboard_api_url` to the base URL of your wgdashboard (e.g. `https://localhost:8080`) and `wgdashboard_api_key` to your API key.
+
 ### 3. Set Up Permissions and Schedule the Script
 
 1. Grant execution permissions to the main script:

--- a/wg-clients-guardian.sh
+++ b/wg-clients-guardian.sh
@@ -46,11 +46,83 @@ readonly TELEGRAM_TOKEN=$(awk -F'=' '/^token=/ { print $2}' $1)
 
 readonly WGDASHBOARD_API_URL=$(awk -F'=' '/^wgdashboard_api_url=/ { print $2}' $1)
 readonly WGDASHBOARD_API_KEY=$(awk -F'=' '/^wgdashboard_api_key=/ { print $2}' $1)
+readonly WGDASHBOARD_API_TTL=$(awk -F'=' '/^wgdashboard_api_ttl=/ { print $2}' $1 || echo "86400") # default 24 hours
+readonly WGDASHBOARD_API_RETRY_COUNT=$(awk -F'=' '/^wgdashboard_api_retry_count=/ { print $2}' $1 || echo "3") # default 3 retries
+readonly WGDASHBOARD_API_RETRY_SLEEP=$(awk -F'=' '/^wgdashboard_api_retry_sleep=/ { print $2}' $1 || echo "5") # default 5 second
+readonly WGDASHBOARD_API_CACHE_FILE="$CLIENTS_DIRECTORY/.api_cache"
+
+# Function to get cached API response if available and not expired
+get_cached_api_response() {
+	if [ -f "$WGDASHBOARD_API_CACHE_FILE" ]; then
+		local cache_timestamp=$(head -1 "$WGDASHBOARD_API_CACHE_FILE")
+		local current_time=$(date +%s)
+		local age=$((current_time - cache_timestamp))
+		
+		if [ $age -lt $WGDASHBOARD_API_TTL ]; then
+			sed '1d' "$WGDASHBOARD_API_CACHE_FILE"
+			return 0
+		fi
+	fi
+	return 1
+}
+
+# Function to cache API response with timestamp
+cache_api_response() {
+	local response="$1"
+	local timestamp=$(date +%s)
+	{
+		echo "${timestamp}"
+		echo "$response"
+	} > "$WGDASHBOARD_API_CACHE_FILE"
+}
+
+# Function to fetch API response with retry logic
+fetch_wgdashboard_api() {
+	local retry=0
+	local response=""
+	local peers_data=""
+	
+	# Check if jq is available first
+	if ! command -v jq &> /dev/null; then
+		return 1
+	fi
+	
+	if ! command -v curl &> /dev/null; then
+		return 1
+	fi
+
+	while [ $retry -lt $WGDASHBOARD_API_RETRY_COUNT ]; do
+		response=$(curl -s -H "wg-dashboard-apikey: $WGDASHBOARD_API_KEY" "$WGDASHBOARD_API_URL/api/getWireguardConfigurationInfo?configurationName=wg0" 2>/dev/null)
+
+		if [ -n "$response" ]; then
+			# Extract only id and name from configurationPeers (one JSON object per line, compact format)
+			peers_data=$(echo "$response" | jq -c '.data.configurationPeers[] | {id, name}' 2>/dev/null)
+			
+			if [ -n "$peers_data" ]; then
+				cache_api_response "$peers_data"
+				echo "$peers_data"
+				return 0
+			fi
+		fi
+		
+		retry=$((retry + 1))
+		if [ $retry -lt $WGDASHBOARD_API_RETRY_COUNT ]; then
+			sleep "$WGDASHBOARD_API_RETRY_SLEEP"
+		fi
+	done
+	
+	return 1
+}
 
 # Try wgdashboard API if configured
 if [ -n "$WGDASHBOARD_API_URL" ] && [ -n "$WGDASHBOARD_API_KEY" ]; then
-	# First try header x-api-key
-	api_response=$(curl -s -H "wg-dashboard-apikey: $WGDASHBOARD_API_KEY" "$WGDASHBOARD_API_URL/api/getWireguardConfigurationInfo?configurationName=wg0" 2>/dev/null)
+	# Try to get cached response first
+	api_response=$(get_cached_api_response)
+	
+	# If cache is expired or missing, fetch from API with retries
+	if [ -z "$api_response" ]; then
+		api_response=$(fetch_wgdashboard_api)
+	fi
 fi
 
 while IFS= read -r LINE; do
@@ -71,10 +143,8 @@ while IFS= read -r LINE; do
 		# if client_name_by_public_key is empty, try to look up in wgdashboard via API (preferred)
 		if [ -z "$client_name_by_public_key" ]; then
 			if [ -n "$api_response" ]; then
-				# If jq is available use it to find the peer name by public key
-				if command -v jq &> /dev/null; then
-					client_name_by_public_key=$(echo "$api_response" | jq -r --arg k "$public_key" '.data.configurationPeers[] | select(.id==$k) | .name' 2>/dev/null)
-				fi
+				# Search through cached peers data (one JSON object per line)
+				client_name_by_public_key=$(echo "$api_response" | grep "$public_key" | jq -r '.name' 2>/dev/null)
 				if [ -n "$client_name_by_public_key" ]; then
 					client_name=$client_name_by_public_key
 				fi


### PR DESCRIPTION
This change adds a query to the wgdashboard database to retrieve the client name associated with a WireGuard configuration. The client name is not available from the WireGuard config itself, so querying wgdashboard is required to correctly identify and display the owning client for each configuration.