### PR TITLE
avoid cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,20 @@ Follow these steps to set up the notification service on your WireGuard server.
 
 ### 1. Clone the Repository
 
-Start by cloning this repository onto your server:
+Start by getting the required files onto your server with `curl`:
 
 ```bash
-git clone https://github.com/yourusername/wireguard-client-connection-notification.git
+curl -L -O https://raw.githubusercontent.com/alfiosalanitri/wireguard-client-connection-notification/main/.config-example
+curl -L -O https://raw.githubusercontent.com/alfiosalanitri/wireguard-client-connection-notification/main/wg-clients-guardian.sh
 ```
+
+Alternatively use `wget`:
+
+```bash
+wget https://raw.githubusercontent.com/alfiosalanitri/wireguard-client-connection-notification/main/.config-example
+wget https://raw.githubusercontent.com/alfiosalanitri/wireguard-client-connection-notification/main/wg-clients-guardian.sh
+```
+
 
 ### 2. Configure the Service
 

--- a/wg-clients-guardian.sh
+++ b/wg-clients-guardian.sh
@@ -4,6 +4,7 @@
 #
 # This script is written by Alfio Salanitri <www.alfiosalanitri.it> and are licensed under MIT License.
 # Credits: This script is inspired by https://github.com/pivpn/pivpn/blob/master/scripts/wireguard/clientSTAT.sh
+set -e
 
 # check if wireguard exists
 if ! command -v wg &> /dev/null; then
@@ -24,6 +25,7 @@ fi
 # config constants
 readonly CURRENT_PATH=$(pwd)
 readonly CLIENTS_DIRECTORY="$CURRENT_PATH/clients"
+mkdir -p $CLIENTS_DIRECTORY
 readonly NOW=$(date +%s)
 
 # after X minutes the clients will be considered disconnected


### PR DESCRIPTION
create the clients folder (if missing); fail if any command fails; avoid cloning, simply get the 2 required files